### PR TITLE
Fix check email template.

### DIFF
--- a/lib/email/render.go
+++ b/lib/email/render.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"html"
 	"io/ioutil"
@@ -17,10 +18,10 @@ import (
 func RenderEmailTpl(notify *model.Notify, from model.CookedCommentForEmail, to model.CookedCommentForEmail) string {
 	tplName := config.Instance.Email.MailTpl
 	tpl := ""
-	if _, err := os.Stat(tplName); os.IsExist(err) {
-		tpl = GetExternalEmailTpl(tplName)
-	} else {
+	if _, err := os.Stat(tplName); errors.Is(err, os.ErrNotExist) {
 		tpl = GetInternalEmailTpl(tplName)
+	} else {
+		tpl = GetExternalEmailTpl(tplName)
 	}
 
 	getValue := func(k string, v interface{}) string {


### PR DESCRIPTION
修复检查邮件模板问题。当文件存在的时候 err 为 nil，此时如果调用 os.IsExist(err) 会导致返回总是为 false，从而无法读取用户自定义的邮件模板。